### PR TITLE
Add timeouts in read functions for reliability

### DIFF
--- a/examples/stm32f042.rs
+++ b/examples/stm32f042.rs
@@ -31,7 +31,6 @@ fn main() -> ! {
     hprintln!("Waiting on the sensor...").unwrap();
     delay.delay_ms(1000_u16);
 
-
     loop {
         match dht11::Reading::read(&mut delay, &mut pa1) {
             Ok(dht11::Reading {
@@ -40,8 +39,8 @@ fn main() -> ! {
             }) => hprintln!("{}°, {}% RH", temperature, relative_humidity).unwrap(),
             Err(e) => hprintln!("Error {:?}", e).unwrap(),
         }
-        
+
         // Delay of at least 500ms before polling the sensor again, 1 second or more advised
-        delay.delay_ms(500_u16);  
+        delay.delay_ms(500_u16);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! When initializing the pin as an output, the state of the pin might depend on the specific chip
 //! used. Some might pull the pin low by default causing the sensor to be confused when we actually
-//! read it for the first time. The same thing happens when the sensor is polled too quickly in succession. 
+//! read it for the first time. The same thing happens when the sensor is polled too quickly in succession.
 //! In both of those cases you will get a `DhtError::Timeout`.
 //!
 //! To avoid this, you can pull the pin high when initializing it and polling the sensor with an

--- a/src/read.rs
+++ b/src/read.rs
@@ -5,6 +5,7 @@ use embedded_hal::digital::v2::{InputPin, OutputPin};
 pub enum DhtError<E> {
     PinError(E),
     ChecksumMismatch,
+    Timeout,
 }
 
 impl<E> From<E> for DhtError<E> {
@@ -19,18 +20,18 @@ impl<T> Delay for T where T: DelayMs<u8> + DelayUs<u8> {}
 pub trait InputOutputPin<E>: InputPin<Error = E> + OutputPin<Error = E> {}
 impl<T, E> InputOutputPin<E> for T where T: InputPin<Error = E> + OutputPin<Error = E> {}
 
-fn read_bit<D, E>(delay: &mut D, pin: &impl InputPin<Error = E>) -> Result<bool, E>
+fn read_bit<D, E>(delay: &mut D, pin: &impl InputPin<Error = E>) -> Result<bool, DhtError<E>>
 where
     D: DelayUs<u8>,
 {
-    while pin.is_low()? {}
+    while_with_timeout(delay, || pin.is_low(), 100)?;
     delay.delay_us(35u8);
     let high = pin.is_high()?;
-    while pin.is_high()? {}
+    while_with_timeout(delay, || pin.is_high(), 100)?;
     Ok(high)
 }
 
-fn read_byte<D, E>(delay: &mut D, pin: &impl InputPin<Error = E>) -> Result<u8, E>
+fn read_byte<D, E>(delay: &mut D, pin: &impl InputPin<Error = E>) -> Result<u8, DhtError<E>>
 where
     D: DelayUs<u8>,
 {
@@ -53,8 +54,10 @@ where
     delay.delay_ms(18_u8);
     pin.set_high().ok();
     delay.delay_us(48_u8);
-    while pin.is_low()? {}
-    while pin.is_high()? {}
+
+    while_with_timeout(delay, || pin.is_low(), 100)?;
+    while_with_timeout(delay, || pin.is_high(), 100)?;
+
     let mut data = [0; 4];
     for b in data.iter_mut() {
         *b = read_byte(delay, pin)?;
@@ -65,4 +68,22 @@ where
     } else {
         Ok(data)
     }
+}
+
+/// Loop while the given function returns true or the timeout is reached.
+fn while_with_timeout<E, D, F>(delay: &mut D, func: F, timeout_us: u16) -> Result<(), DhtError<E>> 
+where
+    D: DelayUs<u8>,
+    F: Fn() -> Result<bool, E>
+{
+    let mut count = 0;
+
+    while func()? {
+        delay.delay_us(10_u8);
+        count += 1;
+        if count >= timeout_us {
+            return Err(DhtError::Timeout);
+        }
+    }
+    Ok(())
 }


### PR DESCRIPTION
Hi!
As mentioned in #1, I have implemented a simple timeout strategy for the read functions. This should remove any possibility to end up in an infinite loop.

After some analysis of a bluepill with a DHT22 I have adapted the timeout values to be a bit tighter towards the measured values.

As can be seen in the pictures below the whole communication (after releasing the pin) takes less than 5ms and the individual state changes take between 26 and 78µs. Therefore I set the timeouts to 100µs. This hasn't given me any problems, but it might be worth to test it with a couple of other sensors and especially the DHT11 (I can't test because I don't have that variant).

I have also added the example for the bluepill that I used in the doc, however since the setup of crates, configuration, memory layout is different I marked it as `ignore` so that it does not throw any errors. I'm not sure how we can have examples for multiple boards that compile. 

Let me know if I can improve something

Fixes #1 

![DS1Z_QuickPrint3](https://user-images.githubusercontent.com/7647338/107987104-bfb1a000-6fcd-11eb-80d1-c6a5f70ff66a.png)
![DS1Z_QuickPrint2](https://user-images.githubusercontent.com/7647338/107987105-c04a3680-6fcd-11eb-875b-65e7e954d141.png)
![DS1Z_QuickPrint1](https://user-images.githubusercontent.com/7647338/107987107-c0e2cd00-6fcd-11eb-9a83-85d4d8239bdc.png)
 

