### PR TITLE
fix add with overflow

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -56,7 +56,7 @@ where
         *b = read_byte(delay, pin)?;
     }
     let checksum = read_byte(delay, pin)?;
-    if data.iter().sum::<u8>() != checksum {
+    if data.iter().fold(0u8, |sum, v| sum.wrapping_add(*v)) != checksum {
         Err(DhtError::ChecksumMismatch)
     } else {
         Ok(data)


### PR DESCRIPTION
in some situations `.sum()` may panic `panicked at 'attempt to add with overflow'` 