### PR TITLE
fix: increase read timeout

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -1,6 +1,8 @@
 use embedded_hal::blocking::delay::{DelayMs, DelayUs};
 use embedded_hal::digital::v2::{InputPin, OutputPin};
 
+const TIMEOUT: u16 = 1000;
+
 #[derive(Debug)]
 pub enum DhtError<E> {
     PinError(E),
@@ -21,10 +23,10 @@ pub trait InputOutputPin<E>: InputPin<Error = E> + OutputPin<Error = E> {}
 impl<T, E> InputOutputPin<E> for T where T: InputPin<Error = E> + OutputPin<Error = E> {}
 
 fn read_bit<E>(delay: &mut dyn Delay, pin: &impl InputPin<Error = E>) -> Result<bool, DhtError<E>> {
-    wait_until_timeout(delay, || pin.is_high(), 100)?;
+    wait_until_timeout(delay, || pin.is_high())?;
     delay.delay_us(35u8);
     let high = pin.is_high()?;
-    wait_until_timeout(delay, || pin.is_low(), 100)?;
+    wait_until_timeout(delay, || pin.is_low())?;
     Ok(high)
 }
 
@@ -48,8 +50,8 @@ where
     pin.set_high().ok();
     delay.delay_us(48_u8);
 
-    wait_until_timeout(delay, || pin.is_high(), 100)?;
-    wait_until_timeout(delay, || pin.is_low(), 100)?;
+    wait_until_timeout(delay, || pin.is_high())?;
+    wait_until_timeout(delay, || pin.is_low())?;
 
     let mut data = [0; 4];
     for b in data.iter_mut() {
@@ -64,15 +66,11 @@ where
 }
 
 /// Wait until the given function returns true or the timeout is reached.
-fn wait_until_timeout<E, F>(
-    delay: &mut dyn Delay,
-    func: F,
-    timeout_us: u8,
-) -> Result<(), DhtError<E>>
+fn wait_until_timeout<E, F>(delay: &mut dyn Delay, func: F) -> Result<(), DhtError<E>>
 where
     F: Fn() -> Result<bool, E>,
 {
-    for _ in 0..timeout_us {
+    for _ in 0..TIMEOUT {
         if func()? {
             return Ok(());
         }


### PR DESCRIPTION
I've been playing around with the blocking version before tackling the async side of things and found that my chip needed a longer timeout! I was getting a reply on my oscilloscope, but the driver would report a timeout!

I've changed the timeout to 1ms (which seems to work 100% of the time for me now) and refactored things a bit so that that number is a global constant instead of being repeated in `read.rs`.

Async adventures coming soon!