### PR TITLE
+Working async using `embedded-hal-async`+ (See last comment!)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,20 +18,20 @@ exclude = [
 ]
 
 [features]
-async = ["embassy", "futures"]
+async = ["embedded-hal-async", "embassy-futures"]
 
 [dependencies]
-embedded-hal = "^0.2.4"
-embassy = { version = "*", path = "../../embassy/embassy", optional = true }
-futures = { version = "0.3.8", default-features = false, features = ["async-await"] , optional = true }
+embedded-hal = "0.2.7"
+embedded-hal-async = { version = "0.2.0-alpha.1", optional = true }
+embassy-futures = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
-embassy-stm32l0 = { version = "*", path = "../../embassy/embassy-stm32l0", features = ["stm32l0x2"] }
-stm32f0xx-hal = {version = "0.17.1", features = ["stm32f042"]}
-stm32l0xx-hal = { path = "../../stm32l0xx-hal", version = "0.6.2", features = ["stm32l0x2", "rt"]}
-cortex-m = "0.6.7"
-cortex-m-rt = "0.6.13"
-cortex-m-semihosting = "0.3.7"
+embassy-stm32l0 = "0.0.0"
+stm32f0xx-hal = { version = "0.18.0", features = ["stm32f042"] }
+stm32l0xx-hal = { version = "0.10.0", features = ["stm32l0x2", "rt"] }
+cortex-m = "0.7.7"
+cortex-m-rt = "0.7.3"
+cortex-m-semihosting = "0.5.0"
 panic-halt = "0.2.0"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,18 @@ exclude = [
   ".gitignore",
 ]
 
+[features]
+async = ["embassy", "futures"]
+
 [dependencies]
 embedded-hal = "^0.2.4"
+embassy = { version = "*", path = "../../embassy/embassy", optional = true }
+futures = { version = "0.3.8", default-features = false, features = ["async-await"] , optional = true }
 
 [dev-dependencies]
+embassy-stm32l0 = { version = "*", path = "../../embassy/embassy-stm32l0", features = ["stm32l0x2"] }
 stm32f0xx-hal = {version = "0.17.1", features = ["stm32f042"]}
+stm32l0xx-hal = { path = "../../stm32l0xx-hal", version = "0.6.2", features = ["stm32l0x2", "rt"]}
 cortex-m = "0.6.7"
 cortex-m-rt = "0.6.13"
 cortex-m-semihosting = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,17 +21,17 @@ exclude = [
 async = ["embedded-hal-async", "embassy-futures"]
 
 [dependencies]
-embedded-hal = "0.2.7"
+embedded-hal = "^0.2.4"
 embedded-hal-async = { version = "0.2.0-alpha.1", optional = true }
 embassy-futures = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
-embassy-stm32l0 = "0.0.0"
-stm32f0xx-hal = { version = "0.18.0", features = ["stm32f042"] }
-stm32l0xx-hal = { version = "0.10.0", features = ["stm32l0x2", "rt"] }
-cortex-m = "0.7.7"
-cortex-m-rt = "0.7.3"
-cortex-m-semihosting = "0.5.0"
+embassy-stm32l0 = { version = "*", path = "../../embassy/embassy-stm32l0", features = ["stm32l0x2"] }
+stm32f0xx-hal = {version = "0.17.1", features = ["stm32f042"]}
+stm32l0xx-hal = { path = "../../stm32l0xx-hal", version = "0.6.2", features = ["stm32l0x2", "rt"]}
+cortex-m = "0.6.7"
+cortex-m-rt = "0.6.13"
+cortex-m-semihosting = "0.3.7"
 panic-halt = "0.2.0"
 
 [profile.release]

--- a/examples/async_stm32l072.rs
+++ b/examples/async_stm32l072.rs
@@ -1,0 +1,77 @@
+#![feature(type_alias_impl_trait)]
+#![no_std]
+#![no_main]
+
+use crate::hal::{exti::Exti, pac, prelude::*, rcc, syscfg};
+use cortex_m_rt::entry;
+use cortex_m_semihosting::hprintln;
+use embassy::{
+    executor::{task, Executor},
+    time,
+    traits::delay::Delay,
+    util::Forever,
+};
+use embassy_stm32l0::{exti, interrupt, rtc};
+use futures::pin_mut;
+use panic_halt as _;
+use stm32l0xx_hal as hal;
+
+use dht_sensor::*;
+
+static ALARM: Forever<rtc::Alarm<pac::TIM2>> = Forever::new();
+static EXECUTOR: Forever<Executor> = Forever::new();
+static EXTI: Forever<exti::ExtiManager> = Forever::new();
+static RTC: Forever<rtc::RTC<pac::TIM2>> = Forever::new();
+
+#[task]
+async fn run(mut rcc: rcc::Rcc, gpioa: pac::GPIOA, exti: pac::EXTI, syscfg: pac::SYSCFG) {
+    let gpioa = gpioa.split(&mut rcc);
+
+    let mut button = gpioa.pa4.into_open_drain_output();
+    button.set_high().ok();
+
+    let exti = Exti::new(exti);
+    let syscfg = syscfg::SYSCFG::new(syscfg, &mut rcc);
+    let exti = EXTI.put(exti::ExtiManager::new(exti, syscfg));
+
+    let delay = time::Delay::new();
+    pin_mut!(delay);
+
+    let pin = exti.new_pin(button, interrupt::take!(EXTI4_15));
+    pin_mut!(pin);
+
+    loop {
+        delay.as_mut().delay_ms(1000).await;
+        match dht11::read(delay.as_mut(), pin.as_mut()).await {
+            Ok(dht11::Reading {
+                temperature,
+                relative_humidity,
+            }) => hprintln!("{}°, {}% RH", temperature, relative_humidity).unwrap(),
+            Err(e) => hprintln!("Error {:?}", e).unwrap(),
+        };
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+
+    let rcc = dp.RCC.freeze(hal::rcc::Config::hsi16());
+
+    let rtc = RTC.put(rtc::RTC::new(dp.TIM2, interrupt::take!(TIM2), rcc.clocks));
+    rtc.start();
+
+    let alarm = ALARM.put(rtc.alarm1());
+    unsafe { embassy::time::set_clock(rtc) };
+
+    let executor = EXECUTOR.put(Executor::new());
+    executor.set_alarm(alarm);
+
+    let gpioa = dp.GPIOA;
+    let exti = dp.EXTI;
+    let sc = dp.SYSCFG;
+
+    executor.run(|spawner| {
+        spawner.spawn(run(rcc, gpioa, exti, sc)).unwrap();
+    });
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,6 @@
 #[derive(Debug)]
-pub enum DhtError<E> {
-    PinError(E),
+pub enum DhtError {
+    PinError,
     ChecksumMismatch,
     Timeout,
-}
-
-impl<E> From<E> for DhtError<E> {
-    fn from(error: E) -> DhtError<E> {
-        DhtError::PinError(error)
-    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,12 @@
+#[derive(Debug)]
+pub enum DhtError<E> {
+    PinError(E),
+    ChecksumMismatch,
+    Timeout,
+}
+
+impl<E> From<E> for DhtError<E> {
+    fn from(error: E) -> DhtError<E> {
+        DhtError::PinError(error)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,11 +77,16 @@
 //! ```
 #![cfg_attr(not(test), no_std)]
 
+mod error;
+mod pin;
 mod read;
-pub use read::{Delay, DhtError, InputOutputPin};
+
+pub use error::DhtError;
+pub use pin::InputOutputPin;
+pub use read::Delay;
 
 pub trait DhtReading: internal::FromRaw + Sized {
-    fn read<P, E>(delay: &mut dyn Delay, pin: &mut P) -> Result<Self, read::DhtError<E>>
+    fn read<P, E>(delay: &mut dyn Delay, pin: &mut P) -> Result<Self, DhtError<E>>
     where
         P: InputOutputPin<E>,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,14 @@ mod error;
 mod pin;
 mod read;
 
+#[cfg(feature = "async")]
+mod read_async;
+
+#[cfg(feature = "async")]
+use core::pin::Pin;
+#[cfg(feature = "async")]
+use embassy::traits::{delay, gpio::*};
+
 pub use error::DhtError;
 pub use pin::InputOutputPin;
 pub use read::Delay;
@@ -125,6 +133,17 @@ pub mod dht11 {
     }
 
     impl DhtReading for Reading {}
+
+    #[cfg(feature = "async")]
+    pub async fn read<E, D, T>(delay: Pin<&mut D>, pin: Pin<&mut T>) -> Result<Reading, DhtError<E>>
+    where
+        D: delay::Delay,
+        T: Unpin + WaitForHigh + WaitForLow + InputOutputPin<E>,
+    {
+        read_async::read_raw(delay, pin)
+            .await
+            .map(<Reading as internal::FromRaw>::raw_to_reading)
+    }
 
     #[test]
     fn test_raw_to_reading() {
@@ -174,6 +193,17 @@ pub mod dht22 {
     }
 
     impl DhtReading for Reading {}
+
+    #[cfg(feature = "async")]
+    pub async fn read<E, D, T>(delay: Pin<&mut D>, pin: Pin<&mut T>) -> Result<Reading, DhtError<E>>
+    where
+        D: delay::Delay,
+        T: Unpin + WaitForHigh + WaitForLow + InputOutputPin<E>,
+    {
+        read_async::read_raw(delay, pin)
+            .await
+            .map(<Reading as internal::FromRaw>::raw_to_reading)
+    }
 
     #[test]
     fn test_raw_to_reading() {

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -1,4 +1,0 @@
-use embedded_hal::digital::v2::{InputPin, OutputPin};
-
-pub trait InputOutputPin<E>: InputPin<Error = E> + OutputPin<Error = E> {}
-impl<T, E> InputOutputPin<E> for T where T: InputPin<Error = E> + OutputPin<Error = E> {}

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -1,0 +1,4 @@
+use embedded_hal::digital::v2::{InputPin, OutputPin};
+
+pub trait InputOutputPin<E>: InputPin<Error = E> + OutputPin<Error = E> {}
+impl<T, E> InputOutputPin<E> for T where T: InputPin<Error = E> + OutputPin<Error = E> {}

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,24 +1,11 @@
 use embedded_hal::blocking::delay::{DelayMs, DelayUs};
-use embedded_hal::digital::v2::{InputPin, OutputPin};
+use embedded_hal::digital::v2::InputPin;
 
-#[derive(Debug)]
-pub enum DhtError<E> {
-    PinError(E),
-    ChecksumMismatch,
-    Timeout,
-}
-
-impl<E> From<E> for DhtError<E> {
-    fn from(error: E) -> DhtError<E> {
-        DhtError::PinError(error)
-    }
-}
+use crate::error::*;
+use crate::pin::*;
 
 pub trait Delay: DelayUs<u8> + DelayMs<u8> {}
 impl<T> Delay for T where T: DelayMs<u8> + DelayUs<u8> {}
-
-pub trait InputOutputPin<E>: InputPin<Error = E> + OutputPin<Error = E> {}
-impl<T, E> InputOutputPin<E> for T where T: InputPin<Error = E> + OutputPin<Error = E> {}
 
 fn read_bit<E>(delay: &mut dyn Delay, pin: &impl InputPin<Error = E>) -> Result<bool, DhtError<E>> {
     wait_until_timeout(delay, || pin.is_high(), 100)?;

--- a/src/read_async.rs
+++ b/src/read_async.rs
@@ -1,0 +1,60 @@
+use core::pin::Pin;
+use embassy::time::Instant;
+use embassy::traits::{delay::Delay, gpio::*};
+use embedded_hal::digital::v2::InputPin;
+
+use crate::error::*;
+use crate::pin::*;
+
+async fn read_bit<T, E>(mut pin: Pin<&mut T>) -> Result<bool, DhtError<E>>
+where
+    T: WaitForHigh + WaitForLow + InputPin<Error = E>,
+{
+    pin.as_mut().wait_for_high().await;
+    let start = Instant::now();
+    pin.as_mut().wait_for_low().await;
+    // This is fragile because of TICKS_PER_SECOND in embassy but appears to work 99% of the time
+    Ok(start.elapsed().as_micros() > 40)
+}
+
+async fn read_byte<T, E>(mut pin: Pin<&mut T>) -> Result<u8, DhtError<E>>
+where
+    T: WaitForHigh + WaitForLow + InputPin<Error = E>,
+{
+    let mut byte: u8 = 0;
+    for i in 0..8 {
+        let bit_mask = 1 << (7 - (i % 8));
+        if read_bit(pin.as_mut()).await? {
+            byte |= bit_mask;
+        }
+    }
+    Ok(byte)
+}
+
+pub async fn read_raw<E, D, T>(
+    mut delay: Pin<&mut D>,
+    mut pin: Pin<&mut T>,
+) -> Result<[u8; 4], DhtError<E>>
+where
+    D: Delay,
+    T: Unpin + WaitForHigh + WaitForLow + InputOutputPin<E>,
+{
+    let mut data = [0; 4];
+    pin.set_low().ok();
+    delay.as_mut().delay_ms(18).await;
+    pin.set_high().ok();
+
+    pin.as_mut().wait_for_low().await;
+    pin.as_mut().wait_for_high().await;
+    pin.as_mut().wait_for_low().await;
+
+    for b in data.iter_mut() {
+        *b = read_byte(pin.as_mut()).await?;
+    }
+    let checksum = read_byte(pin).await?;
+    if data.iter().fold(0u8, |sum, v| sum.wrapping_add(*v)) != checksum {
+        Err(DhtError::ChecksumMismatch)
+    } else {
+        Ok(data)
+    }
+}

--- a/src/read_async.rs
+++ b/src/read_async.rs
@@ -1,60 +1,59 @@
-use core::pin::Pin;
-use embassy::time::Instant;
-use embassy::traits::{delay::Delay, gpio::*};
-use embedded_hal::digital::v2::InputPin;
+use core::future::Future;
+use embassy_futures::select::{select, Either};
+use embedded_hal::digital::v2::OutputPin;
+use embedded_hal_async::{delay::DelayUs, digital::Wait};
 
 use crate::error::*;
-use crate::pin::*;
 
-async fn read_bit<T, E>(mut pin: Pin<&mut T>) -> Result<bool, DhtError<E>>
-where
-    T: WaitForHigh + WaitForLow + InputPin<Error = E>,
-{
-    pin.as_mut().wait_for_high().await;
-    let start = Instant::now();
-    pin.as_mut().wait_for_low().await;
-    // This is fragile because of TICKS_PER_SECOND in embassy but appears to work 99% of the time
-    Ok(start.elapsed().as_micros() > 40)
+const TIMEOUT: u32 = 1000;
+
+async fn read_bit(delay: &mut impl DelayUs, pin: &mut impl Wait) -> Result<bool, DhtError> {
+    await_with_timeout(delay, pin.wait_for_rising_edge()).await?;
+    Ok(matches!(
+        select(pin.wait_for_low(), delay.delay_us(28)).await,
+        Either::Second(_)
+    ))
 }
 
-async fn read_byte<T, E>(mut pin: Pin<&mut T>) -> Result<u8, DhtError<E>>
-where
-    T: WaitForHigh + WaitForLow + InputPin<Error = E>,
-{
+async fn read_byte(delay: &mut impl DelayUs, pin: &mut impl Wait) -> Result<u8, DhtError> {
     let mut byte: u8 = 0;
     for i in 0..8 {
         let bit_mask = 1 << (7 - (i % 8));
-        if read_bit(pin.as_mut()).await? {
+        if read_bit(delay, pin).await? {
             byte |= bit_mask;
         }
     }
     Ok(byte)
 }
 
-pub async fn read_raw<E, D, T>(
-    mut delay: Pin<&mut D>,
-    mut pin: Pin<&mut T>,
-) -> Result<[u8; 4], DhtError<E>>
+pub async fn read_raw<D, T>(delay: &mut D, pin: &mut T) -> Result<[u8; 4], DhtError>
 where
-    D: Delay,
-    T: Unpin + WaitForHigh + WaitForLow + InputOutputPin<E>,
+    D: DelayUs,
+    T: Wait + OutputPin,
 {
     let mut data = [0; 4];
     pin.set_low().ok();
-    delay.as_mut().delay_ms(18).await;
+    delay.delay_ms(18).await;
     pin.set_high().ok();
 
-    pin.as_mut().wait_for_low().await;
-    pin.as_mut().wait_for_high().await;
-    pin.as_mut().wait_for_low().await;
+    await_with_timeout(delay, pin.wait_for_low()).await?;
+    await_with_timeout(delay, pin.wait_for_high()).await?;
+    await_with_timeout(delay, pin.wait_for_low()).await?;
 
     for b in data.iter_mut() {
-        *b = read_byte(pin.as_mut()).await?;
+        *b = read_byte(delay, pin).await?;
     }
-    let checksum = read_byte(pin).await?;
+    let checksum = read_byte(delay, pin).await?;
     if data.iter().fold(0u8, |sum, v| sum.wrapping_add(*v)) != checksum {
         Err(DhtError::ChecksumMismatch)
     } else {
         Ok(data)
+    }
+}
+
+async fn await_with_timeout(delay: &mut impl DelayUs, future: impl Future) -> Result<(), DhtError> {
+    match select(future, delay.delay_ms(TIMEOUT)).await {
+        Either::First(_) => Ok(()),
+        Either::Second(_) => Err(DhtError::Timeout),
     }
 }


### PR DESCRIPTION
It's a bit messy still because I need some testing and input from @michaelbeaumont , but it works beautifully on my Pi Pico using Embassy!

Here is the example code that works on my Pico:
```rust
#![no_std]
#![no_main]
#![feature(type_alias_impl_trait)]

use defmt::*;
use dht_sensor::*;
use embassy_executor::Spawner;
use embassy_rp::gpio::{Level, OutputOpenDrain};
use embassy_time::{Delay, Duration, Timer};
use {defmt_rtt as _, panic_probe as _};

#[embassy_executor::main]
async fn main(_spawner: Spawner) {
    // Initialise Peripherals
    let p = embassy_rp::init(Default::default());

    // Pull the pin high for initialisation
    let mut sensor_pin = OutputOpenDrain::new(p.PIN_12, Level::High);

    // Wait for the sensor to initialise...
    info!("Waiting on the sensor...");
    Timer::after(Duration::from_secs(1)).await;

    // Loop
    loop {
        match dht22::read(&mut Delay, &mut sensor_pin).await {
            Ok(dht22::Reading {
                temperature,
                relative_humidity,
            }) => info!("{}°C, {}% RH", temperature, relative_humidity),
            Err(e) => match e {
                DhtError::PinError => error!("Pin Error!"),
                DhtError::ChecksumMismatch => error!("Checksum Mismatch!"),
                DhtError::Timeout => error!("Timeout!"),
            },
        }

        // Wait 1s
        Timer::after(Duration::from_secs(1)).await;
    }
}
```

Pretty much identical to how I was using the sync version before!

Now I suppose I need your help to:

1. Test the `stm32f042` examples
2. Let me know if you're alright getting rid of the `<E>` generic on the Error type — it was a source of frustration when implementing the `await_with_timeout()` function and all of my error types were `Infallible` anyways so I removed that bit of information? It's nicer working without the generics everywhere, but it does lose a bit of information and I'm not thrilled with my stop-gap in the sync `read.rs` file... If you want that back, I'll add that back and add in some turbofish annotations that I think should fix the issues I ran into in `read_async.rs`
3. Let me know if you're okay replacing `InputOutputPin<E>` with just `InputPin + OutputPin` — kinda tied to point 2 I suppose!
4. If possible, those dev-dependencies should probably be updated to use things from `crates.io` — currently any cargo commands that build the examples fail because they can't resolve those local paths!
5. Finally, since the dependency tree from adding in async is relatively insignificant (see `cargo tree` below), how would you feel about splitting the library into `blocking` and `async` modules and getting rid of the feature flag? Might help to disentangle things a bit, let's users use both APIs at once (if they ever need to) and shouldn't affect the compile-time much at all!

![image](https://user-images.githubusercontent.com/6251883/233797174-102dc50e-63c3-4710-bfa4-c3b67c6f5adc.png)

Thanks for the lovely library! Now I just need your help to polish up what's already here!