### PR TITLE
refactor!: simplifies code and prepares for async

### DIFF
--- a/examples/stm32f042.rs
+++ b/examples/stm32f042.rs
@@ -32,7 +32,7 @@ fn main() -> ! {
     delay.delay_ms(1000_u16);
 
     loop {
-        match dht11::Reading::read(&mut delay, &mut pa1) {
+        match dht11::read(&mut delay, &mut pa1) {
             Ok(dht11::Reading {
                 temperature,
                 relative_humidity,


### PR DESCRIPTION
- The `internal` module and DhtReading traits were replaced with plain
  functions to allow for different initialization durations for the
  `dht11` and `dht22` drivers
- Timeout was changed from a `u16` to a `u8`
- Trait objects were replaced by static dispatch using `impl`
- Updates the call to `read` in the example code